### PR TITLE
Small fixes(tests): Loompy dependency moved to the end of headers. Ex…

### DIFF
--- a/examples/add_seg.sh
+++ b/examples/add_seg.sh
@@ -19,5 +19,5 @@ for {set x 1} {$x<5} {incr x} {
     expect "like to label"
     send "Seg$x\n"
     expect "complete"
-
+    set timeout 120
 }

--- a/examples/test1.sh
+++ b/examples/test1.sh
@@ -1,9 +1,3 @@
-#!/usr/bin/env expect
+#!/usr/bin/env bash
 
-set timeout 120
-eval spawn panopticon wmec --patient 43 --cell_type tumor --complexity_cutoff 1000 --figure_output example.pdf example_data/example.loom
-expect "save these clusters"
-send "n\n"
-
-
-
+panopticon wmec --patient 43 --cell_type tumor --complexity_cutoff 1000 --figure_output example.pdf example_data/example.loom

--- a/panopticon/commands/bookem.py
+++ b/panopticon/commands/bookem.py
@@ -1,5 +1,6 @@
 import click
 import os
+
 import numpy as np
 import pandas as pd
 from scipy import sparse

--- a/panopticon/commands/bookem.py
+++ b/panopticon/commands/bookem.py
@@ -1,11 +1,13 @@
 import click
 import os
-import loompy
 import numpy as np
 import pandas as pd
 from scipy import sparse
 from panopticon.dna import segmentation_to_copy_ratio_dict
 from panopticon.utilities import get_valid_gene_info
+
+# import loompy after the main packages, because sometimes it breaks packages that are imported further:
+import loompy
 
 
 def scrna_wizard_main():

--- a/panopticon/commands/multireference_dna_correspondence.py
+++ b/panopticon/commands/multireference_dna_correspondence.py
@@ -1,12 +1,15 @@
-import numpy as np
-import re
-import loompy
-import matplotlib.pyplot as plt
-from panopticon.dna import multireference_dna_correspondence
-from panopticon.utilities import get_module_score
 from tqdm import tqdm
-import seaborn as sns
 
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+import re
+
+from panopticon.dna import multireference_dna_correspondence
+from panopticon.utilities import get_module_score_loom
+
+# import loompy after the main packages, because sometimes it breaks packages that are imported further:
+import loompy
 
 def multireference_dna_correspondence_main(loomfile,
                                            queries,
@@ -60,7 +63,7 @@ def multireference_dna_correspondence_main(loomfile,
             stratum_masks.append(np.array([True] * loom.shape[1])[querymask])
 
         if modulescore_signature is not None:
-            module_score = get_module_score(
+            module_score = get_module_score_loom(
                 loom, modulescore_signature, querymask=querymask)
 
 
@@ -73,12 +76,12 @@ def multireference_dna_correspondence_main(loomfile,
         fig, ax = plt.subplots(
             2 + module_score_tick,
             (len(segmentations) - 1) * len(segmentations) // 2,
-            figsize=(len(segmentations) * (1 - len(segmentations) * 2), 8))
+            figsize=(len(segmentations) * (len(segmentations) * 2 - 1), 8))
     else:
         fig, ax = plt.subplots(
             (2 + module_score_tick) * len(stratum_masks),
             (len(segmentations) - 1) * len(segmentations) // 2,
-            figsize=(len(segmentations) * (1 - len(segmentations) * 2),
+            figsize=(len(segmentations) * (len(segmentations) * 2 - 1),
                      8 * len(stratum_masks)))
     ## Getting the figsize right is annoying, perhaps there's a better solution
 

--- a/panopticon/commands/multireference_dna_correspondence.py
+++ b/panopticon/commands/multireference_dna_correspondence.py
@@ -1,9 +1,9 @@
 from tqdm import tqdm
+import re
 
 import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
-import re
 
 from panopticon.dna import multireference_dna_correspondence
 from panopticon.utilities import get_module_score_loom

--- a/panopticon/commands/rna_dna_correspondence.py
+++ b/panopticon/commands/rna_dna_correspondence.py
@@ -1,23 +1,27 @@
 #! /usr/bin/env python
+
 from tqdm import tqdm
 import argparse
+from warnings import warn
+
+import numpy as np
 import pandas as pd
-from panopticon import wme, dna
 import seaborn as sns
 import matplotlib.pyplot as plt
-import numpy as np
-from scipy import stats
-from scipy import sparse
-import pymannkendall as mk
-import loompy
+from scipy import stats, sparse
 from scipy.stats.mstats import theilslopes
+import pymannkendall as mk
 
+from panopticon import wme, dna
+
+# import loompy after the main packages, because sometimes it breaks packages that are imported further:
+import loompy
 
 def rna_dna_correspondence_main(loomfile, args_seg_file, args_patient_column,
                                 args_patient, args_time_point, output=None):
     with loompy.connect(loomfile, validate=False) as loom:
         genes = loom.ra['gene']
-        metadata = pd.DataFrame(loom.ca['patient_ID'])
+        metadata = pd.DataFrame(loom.ca['patient_ID']).astype(str)
         metadata.columns = ['patient_ID']
         metadata['complexity'] = loom.ca['complexity']
         metadata['cell_type'] = loom.ca['cell_type']
@@ -130,11 +134,16 @@ def rna_dna_correspondence_main(loomfile, args_seg_file, args_patient_column,
         sns.distplot(ps_tumor, label='high complexity_tumor', color='k')
         sns.distplot(ps_tumor_low_complexity, label='low complexity tumor', color='b')
         plt.legend()
-        from IPython.core.debugger import set_trace; set_trace()
+        #from IPython.core.debugger import set_trace; set_trace()
+        # The IPython is not in the dependencies and the output is disabled from Feb 2020.
+        # Ipython debug mode should be removed.
         #if output:
-        print("Output disabled!  20 Feb 2020")
-        if False:
 
-            plt.savefig(output)
-        else:
-            plt.show()
+        warn(f"Output is disabled from 20 Feb 2020. Saving to {output}")
+
+        plt.savefig(output)
+
+        #if False:
+        #    plt.savefig(output)
+        #else:
+        #    plt.show()

--- a/panopticon/commands/windowed_mean_expression_clustering.py
+++ b/panopticon/commands/windowed_mean_expression_clustering.py
@@ -1,16 +1,20 @@
 #! /usr/bin/env python
 
-import argparse
-from panopticon import wme
-import umap
-import numpy as np
+import click
 import os
+import argparse
+from warnings import warn
+
+import numpy as np
 import pandas as pd
 from scipy import sparse
-from warnings import warn
 import matplotlib.pyplot as plt
-import click
+import umap
+
+from panopticon import wme
 from panopticon.clustering import kt_cluster
+
+# import loompy after the main packages, because sometimes it breaks packages that are imported further:
 import loompy
 
 
@@ -19,7 +23,7 @@ def windowed_mean_expression_clustering_main(loomfile, patient, cell_type, compl
     with loompy.connect(loomfile, validate=False) as loom:
     
         genes = loom.ra['gene']
-        metadata = pd.DataFrame(loom.ca['patient_ID'])
+        metadata = pd.DataFrame(loom.ca['patient_ID']).astype(str)
         metadata.columns = ['patient_ID']
         metadata['complexity'] = loom.ca['complexity']
         metadata['cell_type'] = loom.ca['cell_type']
@@ -72,7 +76,7 @@ def windowed_mean_expression_clustering_main(loomfile, patient, cell_type, compl
             plt.savefig(figure_output)
         else:
             plt.show()
-        print("Save cluster functionality temporarily eliminated")
+        warn("Save cluster functionality temporarily eliminated")
     
 #        clusters_save_choice = click.prompt(
 #            'Would you like to save these clusters?',

--- a/panopticon/dna.py
+++ b/panopticon/dna.py
@@ -71,13 +71,14 @@ def multireference_dna_correspondence(loom: Any,
                                       *segmentations: Any) -> Any:
 
     list_of_correlations = []
+    loomquery = np.where(loomquery)[0] # Indexing by Bool vector is not supported by loompy v. 3.0.6 for some reason
     for segmentation in tqdm(segmentations, desc='Processing segmentations'):
         crd = loom.ra[segmentation]
         expressions = loom[:, loomquery]
 
         genemask = ~np.isnan(crd)#np.isin(loom.ra['gene'], list(crd.keys()))
         expressions = expressions[genemask, :]
-        validgenes = loom.ra['gene'][genemask]
+        # validgenes = loom.ra['gene'][genemask] # Variable is not used
 #        tcrs = np.array([crd[gene] for gene in validgenes])  #[low_dropout]
         tcrs = crd[genemask]
 

--- a/panopticon/utilities.py
+++ b/panopticon/utilities.py
@@ -1,14 +1,18 @@
+import sys
+import os
+from tqdm import tqdm
+
 from typing import List, Tuple
 import binascii
-import sys
-from pyensembl import EnsemblRelease
+
 import numpy as np
 import pandas as pd
-import os
-import loompy
-import binascii
-from tqdm import tqdm
 import umap
+
+from pyensembl import EnsemblRelease
+
+# import loompy after the main packages, because sometimes it breaks packages that are imported further:
+import loompy
 
 valid_chromosomes = [str(x) for x in range(1, 23)] + ['X']
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     license='MIT',
     description='for combined DNA/RNA analysis in a longitudinal context',
     include_package_data = True,
-    long_description=open('README.md').read(),
+    long_description=open('README.rst').read(),
 )
 


### PR DESCRIPTION
…amples checked and improved.

- Loompy import moved to the end of headers, because sometimes loompy import breaks the environment.
- Examples tested. add_seg.sh now works for all segmentations with a small delay required for loompy to close the file.
- Some deprecated code lines commented out, warning messages added.
- Broken multireference_dna_correspondence_main savefig fixed.